### PR TITLE
Display episodes in show pages and add UI/UX plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 - After each committed PR, update `DEV_PLAN.md` to capture new work and next steps.
 - Run `npm test` before every commit to ensure tests pass.
 - Keep `FILE_STRUCTURE.md` updated to reflect the current project layout whenever files are added, removed, or relocated.
+- Keep `UI_UX_PLAN.md` current with the latest UI/UX planning decisions.

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -35,6 +35,8 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 ### Web Interface
 - [x] Scaffold a React-based web app with navigation for home and show-specific pages.
 - [ ] Fetch data through API clients and display basic lists for shows, episodes, and characters.
+  - [x] Display episode lists for South Park and Bob's Burgers.
+  - [ ] Display character lists for each show.
 - [ ] Apply responsive styling to ensure usability across devices.
 
 ### Interactive Visualization Components
@@ -45,7 +47,7 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 
 ### Handling Missing Family Guy API
 - [ ] Gracefully handle missing data sources
-  - Detect when a show lacks an API (e.g., Family Guy) and display an informative message.
+  - [x] Detect when a show lacks an API (e.g., Family Guy) and display an informative message.
   - Offer links to alternative sources (IMDb, TMDb) or allow manual data uploads.
   - Log unserved requests for potential future API integrations.
 
@@ -55,5 +57,6 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 - [x] Added Bob's Burgers API client with pagination and name filtering.
 - [x] Defined unified data model with normalization helpers and in-memory store.
 - [x] Scaffolding for React-based web interface with basic navigation.
+- [x] Added episode listings to show pages and handled missing API for Family Guy.
 
 

--- a/FILE_STRUCTURE.md
+++ b/FILE_STRUCTURE.md
@@ -4,6 +4,7 @@
 ├── DEV_PLAN.md
 ├── FILE_STRUCTURE.md
 ├── Sourses_info.md
+├── UI_UX_PLAN.md
 ├── package-lock.json
 ├── package.json
 ├── src
@@ -25,4 +26,4 @@
 │   └── southPark.test.ts
 └── tsconfig.json
 
-6 directories, 20 files
+6 directories, 21 files

--- a/UI_UX_PLAN.md
+++ b/UI_UX_PLAN.md
@@ -1,0 +1,24 @@
+# UI/UX Plan
+
+## Overview
+The Showinfo app is an interactive infographic builder that fetches data about TV shows. The interface guides users from a home screen to show-specific pages where data and visualizations are presented.
+
+## Current Layout
+- **Home**: lists available shows and links to their pages.
+- **Show Page**: displays episode lists for supported shows and informs users when no API is available (e.g., Family Guy).
+
+## Visual Libraries
+To build rich infographics, the app will leverage JavaScript visualization libraries highlighted in `Sourses_info.md`:
+- **D3.js** for bespoke, highly customizable visuals.
+- **Chart.js** for common chart types with minimal setup.
+- **Plotly.js** for advanced interactive charts and graphs.
+
+## Navigation and Responsiveness
+- Utilize React Router for page navigation.
+- Ensure responsive design so the app works across devices.
+
+## Next Steps
+- Show character lists alongside episodes.
+- Apply basic styling and layout improvements.
+- Integrate the chosen visualization libraries for interactive charts.
+- Investigate alternative data sources or uploads for shows lacking public APIs.

--- a/src/components/ShowPage.tsx
+++ b/src/components/ShowPage.tsx
@@ -1,12 +1,63 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+
+import { getEpisodes as getSouthParkEpisodes } from "../api/southPark";
+import { getEpisodes as getBobsBurgersEpisodes } from "../api/bobsBurgers";
+import {
+  normalizeSouthParkEpisode,
+  normalizeBobsBurgersEpisode
+} from "../models/normalizers";
+import { Episode } from "../models";
 
 const ShowPage: React.FC = () => {
   const { name } = useParams<{ name: string }>();
+  const [episodes, setEpisodes] = useState<Episode[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchEpisodes() {
+      if (!name) return;
+      try {
+        if (name === "south-park") {
+          const data = await getSouthParkEpisodes();
+          setEpisodes(data.map(normalizeSouthParkEpisode));
+        } else if (name === "bobs-burgers") {
+          const data = await getBobsBurgersEpisodes();
+          setEpisodes(data.map(normalizeBobsBurgersEpisode));
+        } else if (name === "family-guy") {
+          setError("No public API available for Family Guy.");
+        } else {
+          setError("Unknown show.");
+        }
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    }
+
+    fetchEpisodes();
+  }, [name]);
+
+  if (error) {
+    return (
+      <div>
+        <h2>{name}</h2>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <h2>{name}</h2>
-      <p>Data and visualizations coming soon.</p>
+      {episodes ? (
+        <ul>
+          {episodes.map((ep) => (
+            <li key={ep.id}>{ep.name}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>Loading episodes...</p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- fetch and display episode lists for South Park and Bob's Burgers, with a notice for missing Family Guy API
- introduce project-wide UI/UX planning document
- update development and agent instructions to track new planning doc

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7f0e4a7908327a26c78d05208c5a1