### PR TITLE
Add character listings for shows

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -34,9 +34,9 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 
 ### Web Interface
 - [x] Scaffold a React-based web app with navigation for home and show-specific pages.
-- [ ] Fetch data through API clients and display basic lists for shows, episodes, and characters.
+- [x] Fetch data through API clients and display basic lists for shows, episodes, and characters.
   - [x] Display episode lists for South Park and Bob's Burgers.
-  - [ ] Display character lists for each show.
+  - [x] Display character lists for each show.
 - [ ] Apply responsive styling to ensure usability across devices.
 
 ### Interactive Visualization Components
@@ -58,5 +58,6 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 - [x] Defined unified data model with normalization helpers and in-memory store.
 - [x] Scaffolding for React-based web interface with basic navigation.
 - [x] Added episode listings to show pages and handled missing API for Family Guy.
+- [x] Added character listings to show pages.
 
 

--- a/UI_UX_PLAN.md
+++ b/UI_UX_PLAN.md
@@ -5,7 +5,7 @@ The Showinfo app is an interactive infographic builder that fetches data about T
 
 ## Current Layout
 - **Home**: lists available shows and links to their pages.
-- **Show Page**: displays episode lists for supported shows and informs users when no API is available (e.g., Family Guy).
+- **Show Page**: displays episode and character lists for supported shows and informs users when no API is available (e.g., Family Guy).
 
 ## Visual Libraries
 To build rich infographics, the app will leverage JavaScript visualization libraries highlighted in `Sourses_info.md`:
@@ -18,7 +18,6 @@ To build rich infographics, the app will leverage JavaScript visualization libra
 - Ensure responsive design so the app works across devices.
 
 ## Next Steps
-- Show character lists alongside episodes.
 - Apply basic styling and layout improvements.
 - Integrate the chosen visualization libraries for interactive charts.
 - Investigate alternative data sources or uploads for shows lacking public APIs.

--- a/src/api/bobsBurgers.ts
+++ b/src/api/bobsBurgers.ts
@@ -68,6 +68,14 @@ export async function getCharacter(id: number): Promise<Character> {
   return request<Character>(`/characters/${id}`);
 }
 
+export async function getCharacters(page = 1, limit = 25): Promise<Character[]> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    skip: String((page - 1) * limit)
+  });
+  return request<Character[]>(`/characters?${params.toString()}`);
+}
+
 interface SearchOptions {
   name?: string;
   page?: number;

--- a/src/api/southPark.ts
+++ b/src/api/southPark.ts
@@ -86,6 +86,10 @@ export async function getCharacter(id: number): Promise<Character> {
   return request<Character>(`/characters/${id}`);
 }
 
+export async function getCharacters(): Promise<Character[]> {
+  return request<Character[]>(`/characters`);
+}
+
 export async function getEpisodes(): Promise<Episode[]> {
   return request<Episode[]>('/episodes');
 }

--- a/src/components/ShowPage.tsx
+++ b/src/components/ShowPage.tsx
@@ -1,29 +1,46 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
-import { getEpisodes as getSouthParkEpisodes } from "../api/southPark";
-import { getEpisodes as getBobsBurgersEpisodes } from "../api/bobsBurgers";
+import {
+  getEpisodes as getSouthParkEpisodes,
+  getCharacters as getSouthParkCharacters
+} from "../api/southPark";
+import {
+  getEpisodes as getBobsBurgersEpisodes,
+  getCharacters as getBobsBurgersCharacters
+} from "../api/bobsBurgers";
 import {
   normalizeSouthParkEpisode,
-  normalizeBobsBurgersEpisode
+  normalizeBobsBurgersEpisode,
+  normalizeSouthParkCharacter,
+  normalizeBobsBurgersCharacter
 } from "../models/normalizers";
-import { Episode } from "../models";
+import { Episode, Character } from "../models";
 
 const ShowPage: React.FC = () => {
   const { name } = useParams<{ name: string }>();
   const [episodes, setEpisodes] = useState<Episode[] | null>(null);
+  const [characters, setCharacters] = useState<Character[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    async function fetchEpisodes() {
+    async function fetchData() {
       if (!name) return;
       try {
         if (name === "south-park") {
-          const data = await getSouthParkEpisodes();
-          setEpisodes(data.map(normalizeSouthParkEpisode));
+          const [eps, chars] = await Promise.all([
+            getSouthParkEpisodes(),
+            getSouthParkCharacters()
+          ]);
+          setEpisodes(eps.map(normalizeSouthParkEpisode));
+          setCharacters(chars.map(normalizeSouthParkCharacter));
         } else if (name === "bobs-burgers") {
-          const data = await getBobsBurgersEpisodes();
-          setEpisodes(data.map(normalizeBobsBurgersEpisode));
+          const [eps, chars] = await Promise.all([
+            getBobsBurgersEpisodes(),
+            getBobsBurgersCharacters()
+          ]);
+          setEpisodes(eps.map(normalizeBobsBurgersEpisode));
+          setCharacters(chars.map(normalizeBobsBurgersCharacter));
         } else if (name === "family-guy") {
           setError("No public API available for Family Guy.");
         } else {
@@ -34,7 +51,7 @@ const ShowPage: React.FC = () => {
       }
     }
 
-    fetchEpisodes();
+    fetchData();
   }, [name]);
 
   if (error) {
@@ -49,6 +66,7 @@ const ShowPage: React.FC = () => {
   return (
     <div>
       <h2>{name}</h2>
+      <h3>Episodes</h3>
       {episodes ? (
         <ul>
           {episodes.map((ep) => (
@@ -57,6 +75,16 @@ const ShowPage: React.FC = () => {
         </ul>
       ) : (
         <p>Loading episodes...</p>
+      )}
+      <h3>Characters</h3>
+      {characters ? (
+        <ul>
+          {characters.map((ch) => (
+            <li key={ch.id}>{ch.name}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>Loading characters...</p>
       )}
     </div>
   );

--- a/test/bobsBurgers.test.ts
+++ b/test/bobsBurgers.test.ts
@@ -19,6 +19,24 @@ describe("Bob's Burgers API", () => {
     expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
   });
 
+  test('fetches characters list with pagination and caches result', async () => {
+    const mockCharacters = [{ id: 1, name: 'Bob Belcher' }];
+    (global as any).fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockCharacters
+    });
+    const { getCharacters } = await import('../src/api/bobsBurgers');
+    const first = await getCharacters(2, 5);
+    expect(first).toEqual(mockCharacters);
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toBe(
+      'https://bobsburgers-api.herokuapp.com/characters?limit=5&skip=5'
+    );
+    const second = await getCharacters(2, 5);
+    expect(second).toEqual(mockCharacters);
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
+  });
+
   test('builds search query with pagination and name filter', async () => {
     (global as any).fetch = jest.fn().mockResolvedValueOnce({
       ok: true,

--- a/test/southPark.test.ts
+++ b/test/southPark.test.ts
@@ -19,6 +19,26 @@ describe('South Park API', () => {
     expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
   });
 
+  test('fetches characters list and caches result', async () => {
+    const mockCharacters = [
+      { id: 1, name: 'Cartman', age: null, sex: null, hair_color: null, occupation: null }
+    ];
+    (global as any).fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: mockCharacters })
+    });
+    const { getCharacters } = await import('../src/api/southPark');
+    const first = await getCharacters();
+    expect(first).toEqual(mockCharacters);
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toBe(
+      'https://spapi.dev/api/characters'
+    );
+    const second = await getCharacters();
+    expect(second).toEqual(mockCharacters);
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
+  });
+
   test('throws DataNotFoundError on 404', async () => {
     (global as any).fetch = jest.fn().mockResolvedValueOnce({ ok: false, status: 404 });
     const { getCharacter, DataNotFoundError } = await import('../src/api/southPark');


### PR DESCRIPTION
## Summary
- expose `getCharacters` endpoints for South Park and Bob's Burgers APIs
- load and render character lists on show pages
- update development and UI/UX plans with character list milestone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7f5ac7a188327b9b848a09e101224