### PR TITLE
Add basic chart.js visualization for show statistics

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -41,9 +41,9 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 
 ### Interactive Visualization Components
 - [ ] Build infographic components
-  - Set up a React frontend in `src/components/` with a router for different shows.
-  - Integrate D3.js for custom charts and Plotly.js or Chart.js for simpler charts.
-  - Add controls for selecting datasets and chart types; ensure responsive layout.
+  - [x] Set up a React frontend in `src/components/` with a router for different shows.
+  - [x] Integrate Chart.js for basic show statistics visualization.
+  - [ ] Add controls for selecting datasets and chart types; ensure responsive layout.
 
 ### Handling Missing Family Guy API
 - [ ] Gracefully handle missing data sources
@@ -59,5 +59,6 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 - [x] Scaffolding for React-based web interface with basic navigation.
 - [x] Added episode listings to show pages and handled missing API for Family Guy.
 - [x] Added character listings to show pages.
+- [x] Introduced Chart.js bar chart for show statistics.
 
 

--- a/FILE_STRUCTURE.md
+++ b/FILE_STRUCTURE.md
@@ -8,22 +8,24 @@
 ├── package-lock.json
 ├── package.json
 ├── src
-│   ├── api
-│   │   ├── bobsBurgers.ts
-│   │   └── southPark.ts
-│   ├── components
-│   │   ├── App.tsx
-│   │   ├── Home.tsx
-│   │   └── ShowPage.tsx
-│   ├── index.tsx
-│   └── models
-│       ├── index.ts
-│       ├── normalizers.ts
-│       └── store.ts
+│   ├── api
+│   │   ├── bobsBurgers.ts
+│   │   └── southPark.ts
+│   ├── components
+│   │   ├── App.tsx
+│   │   ├── Home.tsx
+│   │   ├── ShowPage.tsx
+│   │   └── ShowStats.tsx
+│   ├── index.tsx
+│   └── models
+│       ├── index.ts
+│       ├── normalizers.ts
+│       └── store.ts
 ├── test
-│   ├── bobsBurgers.test.ts
-│   ├── models.test.ts
-│   └── southPark.test.ts
+│   ├── bobsBurgers.test.ts
+│   ├── models.test.ts
+│   └── southPark.test.ts
 └── tsconfig.json
 
-6 directories, 21 files
+6 directories, 22 files
+

--- a/UI_UX_PLAN.md
+++ b/UI_UX_PLAN.md
@@ -5,7 +5,7 @@ The Showinfo app is an interactive infographic builder that fetches data about T
 
 ## Current Layout
 - **Home**: lists available shows and links to their pages.
-- **Show Page**: displays episode and character lists for supported shows and informs users when no API is available (e.g., Family Guy).
+- **Show Page**: displays episode and character lists for supported shows, a bar chart summarizing counts, and informs users when no API is available (e.g., Family Guy).
 
 ## Visual Libraries
 To build rich infographics, the app will leverage JavaScript visualization libraries highlighted in `Sourses_info.md`:
@@ -19,5 +19,5 @@ To build rich infographics, the app will leverage JavaScript visualization libra
 
 ## Next Steps
 - Apply basic styling and layout improvements.
-- Integrate the chosen visualization libraries for interactive charts.
+- Expand Chart.js visualizations with user-selectable datasets and chart types.
 - Investigate alternative data sources or uploads for shows lacking public APIs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.1.9",
         "@types/react-router-dom": "^5.3.3",
+        "chart.js": "^4.4.3",
         "react": "^19.1.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2"
       },
@@ -890,6 +892,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1431,6 +1439,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/ci-info": {
@@ -3286,6 +3306,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "@types/react-router-dom": "^5.3.3",
+    "chart.js": "^4.4.3",
     "react": "^19.1.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2"
   }

--- a/src/components/ShowPage.tsx
+++ b/src/components/ShowPage.tsx
@@ -16,6 +16,7 @@ import {
   normalizeBobsBurgersCharacter
 } from "../models/normalizers";
 import { Episode, Character } from "../models";
+import ShowStats from "./ShowStats";
 
 const ShowPage: React.FC = () => {
   const { name } = useParams<{ name: string }>();
@@ -66,6 +67,7 @@ const ShowPage: React.FC = () => {
   return (
     <div>
       <h2>{name}</h2>
+      <ShowStats episodes={episodes} characters={characters} />
       <h3>Episodes</h3>
       {episodes ? (
         <ul>

--- a/src/components/ShowStats.tsx
+++ b/src/components/ShowStats.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Bar } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from "chart.js";
+import { Episode, Character } from "../models";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+interface Props {
+  episodes: Episode[] | null;
+  characters: Character[] | null;
+}
+
+const ShowStats: React.FC<Props> = ({ episodes, characters }) => {
+  if (!episodes || !characters) {
+    return null;
+  }
+
+  const data = {
+    labels: ["Episodes", "Characters"],
+    datasets: [
+      {
+        label: "Count",
+        data: [episodes.length, characters.length],
+        backgroundColor: [
+          "rgba(75, 192, 192, 0.6)",
+          "rgba(153, 102, 255, 0.6)"
+        ]
+      }
+    ]
+  };
+
+  return <Bar data={data} />;
+};
+
+export default ShowStats;
+


### PR DESCRIPTION
## Summary
- Integrate Chart.js via react-chartjs-2 to visualize episode and character counts.
- Show stats bar chart on each show's page and document new component structure.
- Update development and UI/UX plans to track chart work and future steps.

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b7ffd7e0c483278afa7e9de37bd09d