### PR TITLE
feat: add interactive chart controls

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -43,7 +43,7 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 - [ ] Build infographic components
   - [x] Set up a React frontend in `src/components/` with a router for different shows.
   - [x] Integrate Chart.js for basic show statistics visualization.
-  - [ ] Add controls for selecting datasets and chart types; ensure responsive layout.
+  - [x] Add controls for selecting datasets and chart types; ensure responsive layout.
 
 ### Handling Missing Family Guy API
 - [ ] Gracefully handle missing data sources
@@ -60,5 +60,6 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 - [x] Added episode listings to show pages and handled missing API for Family Guy.
 - [x] Added character listings to show pages.
 - [x] Introduced Chart.js bar chart for show statistics.
+- [x] Added dataset and chart type controls with responsive layout.
 
 

--- a/FILE_STRUCTURE.md
+++ b/FILE_STRUCTURE.md
@@ -5,6 +5,7 @@
 ├── FILE_STRUCTURE.md
 ├── Sourses_info.md
 ├── UI_UX_PLAN.md
+├── README.md
 ├── package-lock.json
 ├── package.json
 ├── src

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# showinfo
+
+showinfo is an interactive infographic builder that fetches TV-show data through public APIs and presents them with dynamic charts.
+
+## Features
+- South Park and Bob's Burgers API clients with data normalization and caching.
+- Unified TypeScript models for shows, episodes, characters, and quotes.
+- React-based interface for browsing shows, episodes, and characters.
+- Interactive Chart.js component with selectable datasets (counts or episodes per season) and chart types (bar or pie).
+- Graceful handling when no API is available (e.g., Family Guy).
+
+## APIs
+- [South Park API](https://publicapi.dev/south-park-quotes-api/) for characters, episodes, locations, and quotes.
+- [Bob's Burgers API](https://publicapi.dev/bob-s-burgers-api/) for episodes, characters, and quotes.
+- Family Guy currently lacks a public API; future updates may link to alternative sources like IMDb or TMDb.
+
+## Visualization Libraries
+- **Chart.js** is currently integrated for quick bar and pie charts.
+- Future plans include exploring **D3.js** and **Plotly.js** for richer, interactive infographics.
+
+## Development Status
+- ✅ South Park API client
+- ✅ Bob's Burgers API client
+- ✅ Unified data model and in-memory store
+- ✅ React web interface with navigation
+- ✅ Dataset and chart-type controls in visualization component
+- 🚧 Apply responsive styling across the app
+- 🚧 Investigate alternative data sources or uploads for shows lacking public APIs
+
+See [DEV_PLAN.md](DEV_PLAN.md) for the full roadmap.
+
+## Running Tests
+1. Install dependencies: `npm install`
+2. Run unit tests: `npm test`

--- a/UI_UX_PLAN.md
+++ b/UI_UX_PLAN.md
@@ -5,7 +5,7 @@ The Showinfo app is an interactive infographic builder that fetches data about T
 
 ## Current Layout
 - **Home**: lists available shows and links to their pages.
-- **Show Page**: displays episode and character lists for supported shows, a bar chart summarizing counts, and informs users when no API is available (e.g., Family Guy).
+- **Show Page**: displays episode and character lists for supported shows, an interactive chart with selectable datasets and chart types, and informs users when no API is available (e.g., Family Guy).
 
 ## Visual Libraries
 To build rich infographics, the app will leverage JavaScript visualization libraries highlighted in `Sourses_info.md`:
@@ -19,5 +19,4 @@ To build rich infographics, the app will leverage JavaScript visualization libra
 
 ## Next Steps
 - Apply basic styling and layout improvements.
-- Expand Chart.js visualizations with user-selectable datasets and chart types.
 - Investigate alternative data sources or uploads for shows lacking public APIs.

--- a/src/components/ShowStats.tsx
+++ b/src/components/ShowStats.tsx
@@ -1,17 +1,26 @@
-import React from "react";
-import { Bar } from "react-chartjs-2";
+import React, { useState } from "react";
+import { Bar, Pie } from "react-chartjs-2";
 import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
   BarElement,
+  ArcElement,
   Title,
   Tooltip,
   Legend
 } from "chart.js";
 import { Episode, Character } from "../models";
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  ArcElement,
+  Title,
+  Tooltip,
+  Legend
+);
 
 interface Props {
   episodes: Episode[] | null;
@@ -19,25 +28,79 @@ interface Props {
 }
 
 const ShowStats: React.FC<Props> = ({ episodes, characters }) => {
+  const [dataset, setDataset] = useState<"counts" | "episodesPerSeason">(
+    "counts"
+  );
+  const [chartType, setChartType] = useState<"bar" | "pie">("bar");
+
   if (!episodes || !characters) {
     return null;
   }
 
-  const data = {
-    labels: ["Episodes", "Characters"],
-    datasets: [
-      {
-        label: "Count",
-        data: [episodes.length, characters.length],
-        backgroundColor: [
-          "rgba(75, 192, 192, 0.6)",
-          "rgba(153, 102, 255, 0.6)"
+  const buildData = () => {
+    if (dataset === "episodesPerSeason") {
+      const counts: Record<string, number> = {};
+      episodes.forEach((ep) => {
+        const season = ep.season !== undefined ? String(ep.season) : "Unknown";
+        counts[season] = (counts[season] || 0) + 1;
+      });
+      const labels = Object.keys(counts).sort((a, b) => +a - +b);
+      return {
+        labels,
+        datasets: [
+          {
+            label: "Episodes",
+            data: labels.map((l) => counts[l]),
+            backgroundColor: labels.map(() => "rgba(75, 192, 192, 0.6)")
+          }
         ]
-      }
-    ]
+      };
+    }
+
+    return {
+      labels: ["Episodes", "Characters"],
+      datasets: [
+        {
+          label: "Count",
+          data: [episodes.length, characters.length],
+          backgroundColor: [
+            "rgba(75, 192, 192, 0.6)",
+            "rgba(153, 102, 255, 0.6)"
+          ]
+        }
+      ]
+    };
   };
 
-  return <Bar data={data} />;
+  const data = buildData();
+
+  return (
+    <div style={{ maxWidth: "600px", margin: "0 auto" }}>
+      <div style={{ display: "flex", gap: "1rem", marginBottom: "1rem" }}>
+        <label>
+          Dataset:
+          <select
+            value={dataset}
+            onChange={(e) => setDataset(e.target.value as any)}
+          >
+            <option value="counts">Counts</option>
+            <option value="episodesPerSeason">Episodes per Season</option>
+          </select>
+        </label>
+        <label>
+          Chart Type:
+          <select
+            value={chartType}
+            onChange={(e) => setChartType(e.target.value as any)}
+          >
+            <option value="bar">Bar</option>
+            <option value="pie">Pie</option>
+          </select>
+        </label>
+      </div>
+      {chartType === "bar" ? <Bar data={data} /> : <Pie data={data} />}
+    </div>
+  );
 };
 
 export default ShowStats;


### PR DESCRIPTION
## Summary
- add dataset and chart-type controls to ShowStats with responsive layout
- document project status and APIs in new README
- update development and UI/UX plans

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b802873620832792e4aa304aaa4413