### PR TITLE
Log missing API requests and offer alternative sources

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -46,10 +46,10 @@ The project aims to build showinfo, an interactive infographic builder that fetc
   - [x] Add controls for selecting datasets and chart types; ensure responsive layout.
 
 ### Handling Missing Family Guy API
-- [ ] Gracefully handle missing data sources
+- [x] Gracefully handle missing data sources
   - [x] Detect when a show lacks an API (e.g., Family Guy) and display an informative message.
-  - Offer links to alternative sources (IMDb, TMDb) or allow manual data uploads.
-  - Log unserved requests for potential future API integrations.
+  - [x] Offer links to alternative sources (IMDb, TMDb) or allow manual data uploads.
+  - [x] Log unserved requests for potential future API integrations.
 
 ## Completed Work
 - [x] Initial project setup.
@@ -61,5 +61,6 @@ The project aims to build showinfo, an interactive infographic builder that fetc
 - [x] Added character listings to show pages.
 - [x] Introduced Chart.js bar chart for show statistics.
 - [x] Added dataset and chart type controls with responsive layout.
+- [x] Added logging and alternative source links for shows without APIs.
 
 

--- a/FILE_STRUCTURE.md
+++ b/FILE_STRUCTURE.md
@@ -18,15 +18,18 @@
 │   │   ├── ShowPage.tsx
 │   │   └── ShowStats.tsx
 │   ├── index.tsx
-│   └── models
-│       ├── index.ts
-│       ├── normalizers.ts
-│       └── store.ts
+│   ├── models
+│   │   ├── index.ts
+│   │   ├── normalizers.ts
+│   │   └── store.ts
+│   └── utils
+│       └── missingApiLogger.ts
 ├── test
 │   ├── bobsBurgers.test.ts
+│   ├── missingApiLogger.test.ts
 │   ├── models.test.ts
 │   └── southPark.test.ts
 └── tsconfig.json
 
-6 directories, 22 files
+7 directories, 24 files
 

--- a/UI_UX_PLAN.md
+++ b/UI_UX_PLAN.md
@@ -5,7 +5,7 @@ The Showinfo app is an interactive infographic builder that fetches data about T
 
 ## Current Layout
 - **Home**: lists available shows and links to their pages.
-- **Show Page**: displays episode and character lists for supported shows, an interactive chart with selectable datasets and chart types, and informs users when no API is available (e.g., Family Guy).
+- **Show Page**: displays episode and character lists for supported shows, an interactive chart with selectable datasets and chart types, and when no API is available (e.g., Family Guy) it offers links to IMDb and TMDb while logging the request.
 
 ## Visual Libraries
 To build rich infographics, the app will leverage JavaScript visualization libraries highlighted in `Sourses_info.md`:
@@ -19,4 +19,4 @@ To build rich infographics, the app will leverage JavaScript visualization libra
 
 ## Next Steps
 - Apply basic styling and layout improvements.
-- Investigate alternative data sources or uploads for shows lacking public APIs.
+- Explore manual data upload options for shows lacking public APIs.

--- a/src/components/ShowPage.tsx
+++ b/src/components/ShowPage.tsx
@@ -17,12 +17,15 @@ import {
 } from "../models/normalizers";
 import { Episode, Character } from "../models";
 import ShowStats from "./ShowStats";
+import { logMissingApi } from "../utils/missingApiLogger";
 
 const ShowPage: React.FC = () => {
   const { name } = useParams<{ name: string }>();
   const [episodes, setEpisodes] = useState<Episode[] | null>(null);
   const [characters, setCharacters] = useState<Character[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [alternativeSources, setAlternativeSources] =
+    useState<{ label: string; url: string }[] | null>(null);
 
   useEffect(() => {
     async function fetchData() {
@@ -43,7 +46,18 @@ const ShowPage: React.FC = () => {
           setEpisodes(eps.map(normalizeBobsBurgersEpisode));
           setCharacters(chars.map(normalizeBobsBurgersCharacter));
         } else if (name === "family-guy") {
+          logMissingApi(name);
           setError("No public API available for Family Guy.");
+          setAlternativeSources([
+            {
+              label: "IMDb",
+              url: "https://www.imdb.com/title/tt0182576/"
+            },
+            {
+              label: "TMDb",
+              url: "https://www.themoviedb.org/tv/1434-family-guy"
+            }
+          ]);
         } else {
           setError("Unknown show.");
         }
@@ -60,6 +74,20 @@ const ShowPage: React.FC = () => {
       <div>
         <h2>{name}</h2>
         <p>{error}</p>
+        {alternativeSources && (
+          <p>
+            Try {""}
+            {alternativeSources.map((src, idx) => (
+              <span key={src.url}>
+                <a href={src.url} target="_blank" rel="noopener noreferrer">
+                  {src.label}
+                </a>
+                {idx < alternativeSources.length - 1 ? " or " : ""}
+              </span>
+            ))}
+            {" "}for more information.
+          </p>
+        )}
       </div>
     );
   }

--- a/src/utils/missingApiLogger.ts
+++ b/src/utils/missingApiLogger.ts
@@ -1,0 +1,15 @@
+const missingApiRequests: string[] = [];
+
+export function logMissingApi(showName: string): void {
+  missingApiRequests.push(showName);
+  console.warn(`No API available for ${showName}`);
+}
+
+export function getMissingApiLog(): string[] {
+  return [...missingApiRequests];
+}
+
+export function clearMissingApiLog(): void {
+  missingApiRequests.length = 0;
+}
+

--- a/test/missingApiLogger.test.ts
+++ b/test/missingApiLogger.test.ts
@@ -1,0 +1,12 @@
+import { logMissingApi, getMissingApiLog, clearMissingApiLog } from '../src/utils/missingApiLogger';
+
+describe('missingApiLogger', () => {
+  beforeEach(() => {
+    clearMissingApiLog();
+  });
+
+  test('records unserved requests', () => {
+    logMissingApi('family-guy');
+    expect(getMissingApiLog()).toEqual(['family-guy']);
+  });
+});


### PR DESCRIPTION
## Summary
- track unsupported show requests with a reusable missing API logger
- show page logs and links to IMDb/TMDb when Family Guy lacks an API
- document new behavior and update development and UI/UX plans

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b80450e9b483278cbce33b0fa05699